### PR TITLE
Fix analog input for toggles, fix buttontype inputMax

### DIFF
--- a/objects/oOptionsDisplay.object.gmx
+++ b/objects/oOptionsDisplay.object.gmx
@@ -232,7 +232,7 @@ display_reset(0, global.opvsync);
         global.tiptext = tip[global.curropt];
     }
     
-    var input = oControl.kRight - oControl.kLeft;
+    var input = (ceil(oControl.kRight) - ceil(oControl.kLeft));
     var inputSteps = oControl.kRightPushedSteps - oControl.kLeftPushedSteps;
     
     // Menu LEFT and RIGHT
@@ -309,7 +309,7 @@ display_reset(0, global.opvsync);
         
         // Button Prompt Style
         if (buttonsEnabled &amp;&amp; global.curropt == opButtonType) {
-            var inputMax = 5 - ((os_type == os_android) * 2);
+            var inputMax = 5;
             oControl.mod_buttonsconfig = wrap(oControl.mod_buttonsconfig + input, 0, inputMax);
             
             // Update events


### PR DESCRIPTION
Analog input was causing out of range values for settings such as Monster Counter and Button Prompt Style.
This results in [!] being displayed, and the setting itself becoming invalid if no digital input is available to correct it. 
This commit also fixes the Button Type being stuck on `XBOX`, by removing the subtraction of the os_type from the inputMax value.